### PR TITLE
feat(thread-creator): multi-channel + creation queue

### DIFF
--- a/docs/functional.md
+++ b/docs/functional.md
@@ -40,7 +40,7 @@ Dès qu'un message est posté dans le salon configuré :
 **Limites :**
 
 - Noms de fils tronqués à 100 caractères (limite Discord)
-- Rate limit : 5 fils max par fenêtre de 10 secondes par serveur — les messages supplémentaires sont ignorés silencieusement
+- Rate limit : 5 fils max par fenêtre de 10 secondes par serveur — les créations excédentaires sont **mises en file d'attente** (FIFO, par serveur) et traitées dès que la fenêtre se libère, au lieu d'être ignorées. File en mémoire : perdue au redémarrage.
 - Messages de bots ignorés
 - Ne fonctionne pas dans les fils, salons vocaux, forum ou annonces
 
@@ -56,11 +56,11 @@ Depuis la v2.0.0, le module utilise le système de configuration générique. Il
 plus de commande dédiée : la configuration se fait via `/config thread-creator`
 (réservé aux administrateurs) et l'activation/désactivation via `/modules`.
 
-| Champ                | Type  | Description                                                                                  |
-| -------------------- | ----- | -------------------------------------------------------------------------------------------- |
-| `channel`            | Salon | Salon à surveiller. Tant qu'il n'est pas défini, rien n'est surveillé.                       |
-| `welcomeMessage`     | Texte | Message posté automatiquement dans chaque fil créé.                                          |
-| `threadNameTemplate` | Texte | Template du nom des fils — variables : `{messageAuthor}`, `{messageContent}`, `{timestamp}`. |
+| Champ                | Type           | Description                                                                                  |
+| -------------------- | -------------- | -------------------------------------------------------------------------------------------- |
+| `channels`           | Salons (liste) | Salons à surveiller (un ou plusieurs, multi-select). Liste vide = rien n'est surveillé.      |
+| `welcomeMessage`     | Texte          | Message posté automatiquement dans chaque fil créé.                                          |
+| `threadNameTemplate` | Texte          | Template du nom des fils — variables : `{messageAuthor}`, `{messageContent}`, `{timestamp}`. |
 
 Il n'y a plus de flag `actif` : désactiver le module via `/modules` arrête la
 surveillance sans effacer la configuration.

--- a/docs/specs/thread-creator-queue.md
+++ b/docs/specs/thread-creator-queue.md
@@ -5,13 +5,15 @@ Priorité : basse
 
 ---
 
-## Problème actuel
+> **Statut : implémenté.** File d'attente et multi-salons (#37) livrés : la classe `ThreadCreationQueue` (`services/thread-creation-queue.ts`) et le champ de config `channels` en `ListOf<CHANNEL>`. Voir « Implémentation » plus bas.
 
-Quand plusieurs messages arrivent rapidement dans le salon surveillé, le rate limit de 5 fils par 10 secondes est atteint et les messages suivants sont silencieusement ignorés. Des fils ne sont donc jamais créés pour ces messages.
+## Problème (avant)
 
-## Comportement cible
+Quand plusieurs messages arrivaient rapidement dans le salon surveillé, le rate limit de 5 fils par 10 secondes était atteint et les messages suivants étaient silencieusement ignorés. Des fils n'étaient donc jamais créés pour ces messages.
 
-Remplacer le drop silencieux par une **file d'attente par serveur** : si le rate limit est atteint, les créations de fils sont mises en attente et traitées dès que la fenêtre de 10 secondes se libère.
+## Comportement
+
+Le drop silencieux est remplacé par une **file d'attente par serveur** : si le rate limit est atteint, les créations de fils sont mises en attente et traitées dès que la fenêtre de 10 secondes se libère.
 
 ### Règles
 
@@ -20,10 +22,26 @@ Remplacer le drop silencieux par une **file d'attente par serveur** : si le rate
 - Si le bot redémarre, les entrées en attente sont perdues (pas de persistance requise).
 - Pas de limite de taille de file définie pour l'instant (à affiner selon les retours).
 
-## Prérequis pour #37 — multi-salons
+### Pourquoi pas de persistance (décision assumée)
 
-L'issue #37 (configurer plusieurs salons par serveur) dépend de cette file : sans elle, surveiller plusieurs salons simultanément amplifierait les drops. Une fois la file en place, #37 peut être implémenté en changeant la clé de configuration de `guildId` vers `(guildId, channelId)`.
+La file est volontairement **en mémoire seule**. Ce qu'on perd à un redémarrage = uniquement les jobs en attente d'un **burst en cours** (le surplus au-delà de 5/10 s pas encore traité) :
+
+- **Sévérité faible** : les messages ne sont pas perdus (ils restent sur Discord) — on rate seulement le _fil auto_ sous certains messages d'un pic, ce qui est cosmétique et rattrapable. C'est l'ancien mode d'échec (drop sur rate limit), désormais réduit à « drop seulement si redémarrage pendant un backlog actif ».
+- **Coût disproportionné** : un job référence un `Message` vivant (non sérialisable) → il faudrait persister `(messageId, channelId, …)`, **re-fetch** les messages au boot et gérer ceux supprimés entre-temps, plus une **table dédiée** — qu'on vient justement de supprimer (clean cut de la migration). Trop pour une feature `priority: low`.
+- **Juste-milieu écarté** : un drain best-effort au graceful shutdown ne couvrirait que les deploys planifiés (pas les crashes) et resterait limité par le délai de grâce + le rate limit → bénéfice marginal.
+
+À reconsidérer seulement si la création de fil devient critique (modération/traçabilité) ou si des pics + redémarrages fréquents rendent la perte visible.
+
+## #37 — multi-salons
+
+L'issue #37 (configurer plusieurs salons par serveur) dépendait de cette file : sans elle, surveiller plusieurs salons amplifierait les drops. La file en place, le multi-salons est livré en passant le champ de config `channel` (salon unique) à **`channels: ListOf<CHANNEL>`** : le service crée un fil si le message est posté dans **l'un** des salons surveillés, et toutes les créations passent par la file (donc partagent la même fenêtre de rate limit par serveur).
 
 ## Impact sur le schéma
 
-Aucun changement de schéma nécessaire pour la file (en mémoire). Depuis la v2.0.0, le module n'a plus de table dédiée : sa configuration vit dans le système générique (`GuildConfiguration`, blob JSON par serveur). Le multi-salons (#37) se traitera donc au niveau du schéma de config du module (champ `channel` unique → liste de salons, type `ListOf<CHANNEL>`), sans migration de table.
+Aucun changement de schéma de base nécessaire (file en mémoire). Depuis la v2.0.0, le module n'a plus de table dédiée : sa configuration vit dans le système générique (`GuildConfiguration`, blob JSON par serveur). Le multi-salons s'est donc fait au niveau du schéma de config du module (`channel` → `channels: ListOf<CHANNEL>`), sans migration de table. **Clean cut** : les configs `channel` (singulier) déjà enregistrées ne sont pas reprises — les serveurs concernés re-sélectionnent leurs salons via `/config thread-creator`.
+
+## Implémentation
+
+- `services/thread-creation-queue.ts` — `ThreadCreationQueue` : file FIFO par serveur, cadence ≤ 5 / 10 s, reprise par `setTimeout` quand la fenêtre est pleine, drain non réentrant (un seul `pump` par serveur). Erreur sur un job loggée sans bloquer la file.
+- `services/thread-creator.service.ts` — `scheduleThreadForMessage` : teste l'appartenance du salon à `channels`, génère le nom du fil, puis enfile le job.
+- Tests : `services/thread-creation-queue.test.ts` (FIFO sans drop sur plusieurs fenêtres, cadence ≤ 5/10 s, isolation par serveur, message de bienvenue) avec fake timers.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "vitest run",
     "test:unit": "vitest run --project unit",
     "test:integration": "vitest run --project integration",
-    "prepare": "lefthook install || true",
+    "prepare": "lefthook install -f || true",
     "format": "oxfmt --write && oxlint --fix --fix-suggestions",
     "prisma:consolidate": "tsx scripts/consolidate-schema.ts",
     "prisma:generate": "pnpm prisma:consolidate && prisma generate --no-hints",

--- a/src/modules/thread-creator/listeners/message-create.listener.ts
+++ b/src/modules/thread-creator/listeners/message-create.listener.ts
@@ -34,7 +34,7 @@ export default declareEventListener<"messageCreate", ThreadCreatorConfigSchema>(
       }
 
       try {
-        await threadCreatorService.createThreadForMessage(message, config);
+        threadCreatorService.scheduleThreadForMessage(message, config);
       } catch (error) {
         logger.error(
           `Erreur dans le listener messageCreate du ThreadCreator : ${error}`

--- a/src/modules/thread-creator/services/thread-creation-queue.test.ts
+++ b/src/modules/thread-creator/services/thread-creation-queue.test.ts
@@ -1,0 +1,85 @@
+import type { Message } from "discord.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ThreadCreationQueue,
+  type ThreadJob,
+} from "./thread-creation-queue.js";
+
+/** Shared startThread spy so a test can count creations across all messages. */
+let startThread: ReturnType<typeof vi.fn>;
+let send: ReturnType<typeof vi.fn>;
+
+function job(name: string, welcomeMessage?: string): ThreadJob {
+  return {
+    message: {
+      id: name,
+      channel: { id: "chan" },
+      startThread,
+    } as unknown as Message,
+    threadName: name,
+    welcomeMessage,
+  };
+}
+
+/** Names passed to startThread, in call order. */
+function createdNames(): string[] {
+  return startThread.mock.calls.map((call) => call[0].name as string);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  send = vi.fn().mockResolvedValue(undefined);
+  startThread = vi.fn().mockResolvedValue({ send });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("ThreadCreationQueue", () => {
+  it("creates every queued thread in FIFO order, across rate-limit windows", async () => {
+    const queue = new ThreadCreationQueue();
+    const names = Array.from({ length: 12 }, (_, i) => `t${i}`);
+
+    names.forEach((name) => queue.enqueue("g1", job(name)));
+    await vi.runAllTimersAsync();
+
+    expect(startThread).toHaveBeenCalledTimes(12);
+    expect(createdNames()).toEqual(names); // nothing dropped, order preserved
+  });
+
+  it("paces at most 5 creations per 10s window", async () => {
+    const queue = new ThreadCreationQueue();
+    Array.from({ length: 6 }, (_, i) => job(`t${i}`)).forEach((j) =>
+      queue.enqueue("g1", j)
+    );
+
+    // Immediate work only — the 6th is held back by the window.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(startThread).toHaveBeenCalledTimes(5);
+
+    // Once the window frees, the 6th goes through.
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(startThread).toHaveBeenCalledTimes(6);
+  });
+
+  it("keeps a separate window per guild", async () => {
+    const queue = new ThreadCreationQueue();
+    for (let i = 0; i < 5; i++) queue.enqueue("g1", job(`a${i}`));
+    for (let i = 0; i < 5; i++) queue.enqueue("g2", job(`b${i}`));
+
+    // Each guild has its own 5-slot window, so all 10 fire immediately.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(startThread).toHaveBeenCalledTimes(10);
+  });
+
+  it("posts the welcome message when one is configured, otherwise not", async () => {
+    const queue = new ThreadCreationQueue();
+    queue.enqueue("g1", job("with", "bienvenue"));
+    queue.enqueue("g1", job("without"));
+    await vi.runAllTimersAsync();
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith("bienvenue");
+  });
+});

--- a/src/modules/thread-creator/services/thread-creation-queue.ts
+++ b/src/modules/thread-creator/services/thread-creation-queue.ts
@@ -1,0 +1,135 @@
+import type { Message } from "discord.js";
+import logger from "../../../lib/logger.js";
+
+/** Pacing window and cap — mirrors Discord's thread-creation rate limit. */
+const RATE_LIMIT_WINDOW_MS = 10_000;
+const MAX_THREADS_PER_WINDOW = 5;
+
+/** A pending thread creation, captured when the source message arrived. */
+export interface ThreadJob {
+  message: Message;
+  threadName: string;
+  welcomeMessage: string | undefined;
+}
+
+/**
+ * Per-guild FIFO queue that paces thread creation at {@link MAX_THREADS_PER_WINDOW}
+ * per {@link RATE_LIMIT_WINDOW_MS}. When the window is full, jobs wait and resume
+ * once it frees instead of being dropped (the previous behaviour).
+ *
+ * In-memory only: pending jobs are lost on restart, queues are per-guild (no
+ * cross-guild sharing), and there is no size cap — see
+ * `docs/specs/thread-creator-queue.md`.
+ */
+export class ThreadCreationQueue {
+  private readonly queues = new Map<string, ThreadJob[]>();
+  private readonly recentCreations = new Map<string, number[]>();
+  private readonly draining = new Set<string>();
+
+  /** Appends a job to the guild's queue and starts draining if not already running. */
+  enqueue(guildId: string, job: ThreadJob): void {
+    const queue = this.queues.get(guildId);
+    if (queue) {
+      queue.push(job);
+    } else {
+      this.queues.set(guildId, [job]);
+    }
+
+    if (!this.draining.has(guildId)) {
+      this.draining.add(guildId);
+      void this.pump(guildId);
+    }
+  }
+
+  /**
+   * Drains a guild's queue in order, pacing creations within the rate-limit
+   * window. When the window is full it reschedules itself for when the oldest
+   * creation ages out; `draining` stays set across the wait so a concurrent
+   * `enqueue` never starts a second pump.
+   */
+  private async pump(guildId: string): Promise<void> {
+    const queue = this.queues.get(guildId) ?? [];
+
+    while (queue.length > 0) {
+      const waitMs = this.msUntilSlotFree(guildId);
+      if (waitMs > 0) {
+        setTimeout(() => void this.pump(guildId), waitMs);
+        return;
+      }
+
+      const job = queue.shift()!;
+      this.recordCreation(guildId);
+      await this.createThread(guildId, job);
+    }
+
+    this.draining.delete(guildId);
+  }
+
+  /** Milliseconds until a creation slot frees up (0 if one is available now). */
+  private msUntilSlotFree(guildId: string): number {
+    const now = Date.now();
+    const recent = (this.recentCreations.get(guildId) ?? []).filter(
+      (timestamp) => timestamp > now - RATE_LIMIT_WINDOW_MS
+    );
+    this.recentCreations.set(guildId, recent);
+
+    if (recent.length < MAX_THREADS_PER_WINDOW) {
+      return 0;
+    }
+    return recent[0]! + RATE_LIMIT_WINDOW_MS - now;
+  }
+
+  private recordCreation(guildId: string): void {
+    const recent = this.recentCreations.get(guildId) ?? [];
+    recent.push(Date.now());
+    this.recentCreations.set(guildId, recent);
+  }
+
+  private async createThread(guildId: string, job: ThreadJob): Promise<void> {
+    const { message, threadName, welcomeMessage } = job;
+    try {
+      const thread = await message.startThread({
+        name: threadName,
+        reason: "Création automatique de fil par ThreadCreator",
+      });
+      if (welcomeMessage) {
+        await thread.send(welcomeMessage);
+      }
+      logger.info(`Fil créé avec succès : "${threadName}" (${guildId})`);
+    } catch (error) {
+      this.logCreationError(error, message, guildId);
+    }
+  }
+
+  /** Logs Discord-specific failures at warn level, anything else at error level. */
+  private logCreationError(
+    error: unknown,
+    message: Message,
+    guildId: string
+  ): void {
+    if (error instanceof Error && "code" in error) {
+      const code = (error as { code: number }).code;
+      if (code === 160004) {
+        logger.warn(
+          `Impossible de créer un fil : le message a été supprimé (${guildId})`
+        );
+        return;
+      }
+      if (code === 160005) {
+        logger.warn(
+          `Limite de fils de discussion atteinte dans ${message.channel.id} (${guildId})`
+        );
+        return;
+      }
+      if (code === 50013) {
+        logger.warn(
+          `Permissions insuffisantes pour créer un fil dans ${message.channel.id} (${guildId})`
+        );
+        return;
+      }
+    }
+    logger.error(
+      `Erreur lors de la création du fil pour le message ${message.id} : ${error}`
+    );
+  }
+}

--- a/src/modules/thread-creator/services/thread-creator.service.ts
+++ b/src/modules/thread-creator/services/thread-creator.service.ts
@@ -1,39 +1,11 @@
-import { ChannelType, type Message, type TextChannel } from "discord.js";
+import type { Message } from "discord.js";
 import type { ConfigProvider } from "../../../lib/config.js";
-import logger from "../../../lib/logger.js";
 import { declareService, type Service } from "../../../lib/service.js";
 import type { ThreadCreatorConfigSchema } from "../thread-creator.config.js";
+import { ThreadCreationQueue } from "./thread-creation-queue.js";
 
 class ThreadCreatorService implements Service {
-  private rateLimitMap = new Map<string, number>();
-  private readonly RATE_LIMIT_WINDOW = 10000; // 10 secondes
-  private readonly MAX_THREADS_PER_WINDOW = 5;
-
-  /**
-   * Vérifie le rate limiting pour éviter de dépasser les limites de l'API Discord
-   */
-  checkRateLimit(guildId: string): boolean {
-    const now = Date.now();
-    const windowStart = now - this.RATE_LIMIT_WINDOW;
-    const key = `${guildId}:${Math.floor(now / this.RATE_LIMIT_WINDOW)}`;
-
-    const currentCount = this.rateLimitMap.get(key) || 0;
-
-    // Nettoyer les anciennes entrées
-    for (const [mapKey, _] of this.rateLimitMap.entries()) {
-      const window = parseInt(mapKey.split(":")[1]!);
-      if (window * this.RATE_LIMIT_WINDOW < windowStart) {
-        this.rateLimitMap.delete(mapKey);
-      }
-    }
-
-    if (currentCount >= this.MAX_THREADS_PER_WINDOW) {
-      return false;
-    }
-
-    this.rateLimitMap.set(key, currentCount + 1);
-    return true;
-  }
+  private readonly queue = new ThreadCreationQueue();
 
   /**
    * Génère un nom pour le fil de discussion en utilisant le template
@@ -68,90 +40,34 @@ class ThreadCreatorService implements Service {
   }
 
   /**
-   * Crée un fil de discussion pour le message donné, selon la configuration du module.
+   * Si le message est posté dans l'un des salons surveillés, planifie la
+   * création d'un fil via la file d'attente (qui respecte le rate limit Discord
+   * sans perdre de message).
    */
-  async createThreadForMessage(
+  scheduleThreadForMessage(
     message: Message,
     config: ConfigProvider<ThreadCreatorConfigSchema>
-  ): Promise<void> {
+  ): void {
     if (!message.guild) {
       return;
     }
 
-    const guildId = message.guild.id;
+    const watchedChannels = config.get("channels");
+    if (
+      !watchedChannels ||
+      !watchedChannels.some((channel) => channel.id === message.channel.id)
+    ) {
+      return;
+    }
 
-    try {
-      // Le module ne surveille que le canal configuré
-      const watchedChannel = config.get("channel");
-      if (!watchedChannel || watchedChannel.id !== message.channel.id) {
-        return;
-      }
-
-      // Vérifier le rate limiting
-      if (!this.checkRateLimit(guildId)) {
-        logger.warn(
-          `Rate limit atteint pour le serveur ${guildId}, création de fil ignorée`
-        );
-        return;
-      }
-
-      // Vérifier que le canal supporte les fils de discussion
-      const channel = message.channel as TextChannel;
-      if (channel.type !== ChannelType.GuildText) {
-        logger.warn(
-          `Le canal ${message.channel.id} ne supporte pas les fils de discussion`
-        );
-        return;
-      }
-
-      // Générer le nom du fil
-      const threadName = this.generateThreadName(
+    this.queue.enqueue(message.guild.id, {
+      message,
+      threadName: this.generateThreadName(
         config.get("threadNameTemplate"),
         message
-      );
-
-      // Créer le fil de discussion
-      const thread = await message.startThread({
-        name: threadName,
-        reason: "Création automatique de fil par ThreadCreator",
-      });
-
-      // Ajouter le message de bienvenue si configuré
-      const welcomeMessage = config.get("welcomeMessage");
-      if (welcomeMessage) {
-        await thread.send(welcomeMessage);
-      }
-
-      logger.info(
-        `Fil créé avec succès : "${threadName}" dans ${channel.name} (${guildId})`
-      );
-    } catch (error) {
-      // Gestion des erreurs spécifiques à l'API Discord
-      if (error instanceof Error && "code" in error) {
-        const discordError = error as { code: number };
-        if (discordError.code === 160004) {
-          logger.warn(
-            `Impossible de créer un fil : le message a été supprimé (${guildId})`
-          );
-        } else if (discordError.code === 160005) {
-          logger.warn(
-            `Limite de fils de discussion atteinte dans ${message.channel.id} (${guildId})`
-          );
-        } else if (discordError.code === 50013) {
-          logger.warn(
-            `Permissions insuffisantes pour créer un fil dans ${message.channel.id} (${guildId})`
-          );
-        } else {
-          logger.error(
-            `Erreur lors de la création du fil pour le message ${message.id}: ${error}`
-          );
-        }
-      } else {
-        logger.error(
-          `Erreur lors de la création du fil pour le message ${message.id}: ${error}`
-        );
-      }
-    }
+      ),
+      welcomeMessage: config.get("welcomeMessage"),
+    });
   }
 }
 

--- a/src/modules/thread-creator/thread-creator.config.ts
+++ b/src/modules/thread-creator/thread-creator.config.ts
@@ -3,14 +3,15 @@ import { ConfigType, type ConfigSchema } from "../../lib/config.js";
 /**
  * Configuration schema for the Thread Creator module, edited via `/config
  * thread-creator`. Whether the module runs at all is governed by module
- * activation (`/modules`), so there is no separate "enabled" flag; an unset
- * `channel` simply means nothing is watched yet.
+ * activation (`/modules`); an empty `channels` list simply means nothing is
+ * watched yet.
  */
 export const threadCreatorConfigSchema = {
-  channel: {
-    name: "Canal surveillé",
-    description: "Canal où surveiller les nouveaux messages.",
-    type: ConfigType.CHANNEL,
+  channels: {
+    name: "Salons surveillés",
+    description:
+      "Salons où surveiller les nouveaux messages (un fil est créé sous chaque message).",
+    type: [ConfigType.CHANNEL],
   },
   welcomeMessage: {
     name: "Message de bienvenue",

--- a/src/modules/thread-creator/thread-creator.module.ts
+++ b/src/modules/thread-creator/thread-creator.module.ts
@@ -9,7 +9,7 @@ export default defineModule({
   name: "Thread Creator",
   description:
     "Crée automatiquement des fils de discussion sous chaque nouveau message dans les canaux configurés. Remplace le bot Needle.",
-  version: "2.0.0",
+  version: "2.1.0",
   author: "AsyncMod Team",
 
   // Configuration éditée via /config thread-creator.


### PR DESCRIPTION
## 🇬🇧 English

### 🎯 Summary

Thread Creator can now watch **several channels per guild**, and paces thread
creation through a **per-guild queue** instead of silently dropping it under
spam. Closes #36 (queue) and #37 (multi-channel).

### 🤔 Motivation

Two linked limitations: under a burst, the 5-threads/10s rate limit silently
**dropped** the extra creations (#36); and only **one** channel could be watched
per guild (#37). #37 depended on #36 — watching more channels without a queue
would only amplify the drops — so both are delivered together.

### 📦 What's included

- ✨ **Queue (#36)** — `ThreadCreationQueue`: per-guild FIFO that paces creation at ≤ 5/10 s and reschedules itself when the window is full, instead of dropping. In-memory (lost on restart), per-guild, no size cap.
- ✨ **Multiple channels (#37)** — config `channel` (single) → **`channels: ListOf<CHANNEL>`** (multi-select). A thread is created when a message lands in **any** watched channel; all of a guild's creations share the same rate-limit window via the queue.
- 🔧 `scheduleThreadForMessage` replaces the old immediate create-or-drop path; the listener calls it synchronously (enqueue is sync).
- 📝 Docs — `thread-creator-queue.md` marked **implemented**, with an explicit _"why no persistence"_ rationale; `functional.md` updated (`channels`, queued instead of dropped). Module bumped to **2.1.0**.
- ✅ Tests — `thread-creation-queue.test.ts` (fake timers): FIFO with no drop across windows, ≤ 5/10 s pacing, per-guild isolation, welcome message. Full suite green (121), tsc / oxlint / oxfmt clean.
- 🧹 **Annex (unrelated tooling)** — one extra commit sets `prepare` to `lefthook install -f` (force hook sync, e.g. over husky leftovers), kept `|| true`.

### 🧭 Notes

- ⚠️ **Clean cut**: stored single-`channel` configs are **not** migrated — guilds that had configured a channel must re-select it under `/config thread-creator` after deploy.
- ⚠️ **No persistence (deliberate)**: queued-but-not-yet-created threads are lost on restart. Rationale documented in the spec (low severity — messages aren't lost, only the auto-thread; full persistence would reintroduce the just-removed dedicated table).
- ⚠️ This branch contains **one tooling commit** (lefthook `-f`) unrelated to thread-creator — folded in at the author's request.

---

## 🇫🇷 Français

### 🎯 Résumé

Thread Creator peut désormais surveiller **plusieurs salons par serveur** et
**met en file** la création de fils (au lieu de l'ignorer silencieusement) sous
le spam. Ferme #36 (queue) et #37 (multi-salons).

### 🤔 Motivation

Deux limitations liées : lors d'un pic, le rate limit de 5 fils/10 s **ignorait**
silencieusement les créations excédentaires (#36) ; et un seul salon pouvait être
surveillé par serveur (#37). #37 dépendait de #36 — surveiller plus de salons
sans file ne ferait qu'amplifier les pertes — donc les deux sont livrés ensemble.

### 📦 Contenu

- ✨ **File (#36)** — `ThreadCreationQueue` : FIFO par serveur, cadence ≤ 5/10 s, se replanifie quand la fenêtre est pleine au lieu de dropper. En mémoire (perdue au redémarrage), par serveur, sans plafond de taille.
- ✨ **Plusieurs salons (#37)** — config `channel` (unique) → **`channels: ListOf<CHANNEL>`** (multi-select). Un fil est créé si le message arrive dans **l'un** des salons surveillés ; toutes les créations d'un serveur partagent la même fenêtre de rate limit via la file.
- 🔧 `scheduleThreadForMessage` remplace l'ancien chemin créer-ou-dropper immédiat ; le listener l'appelle de façon synchrone (l'enfilement est synchrone).
- 📝 Docs — `thread-creator-queue.md` marquée **implémentée**, avec une justification explicite _« pourquoi pas de persistance »_ ; `functional.md` mis à jour (`channels`, mis en file au lieu d'ignoré). Module bumpé en **2.1.0**.
- ✅ Tests — `thread-creation-queue.test.ts` (fake timers) : FIFO sans drop sur plusieurs fenêtres, cadence ≤ 5/10 s, isolation par serveur, message de bienvenue. Suite complète verte (121), tsc / oxlint / oxfmt clean.
- 🧹 **Annexe (tooling sans rapport)** — un commit en plus passe `prepare` à `lefthook install -f` (force la synchro des hooks, ex. par-dessus des résidus husky), `|| true` conservé.

### 🧭 À noter

- ⚠️ **Clean cut** : les configs `channel` (singulier) déjà enregistrées ne sont **pas** reprises — les serveurs concernés doivent re-sélectionner leurs salons via `/config thread-creator` après déploiement.
- ⚠️ **Pas de persistance (assumé)** : les fils en file non encore créés sont perdus au redémarrage. Justification documentée dans la spec (sévérité faible — les messages ne sont pas perdus, seulement le fil auto ; la persistance complète réintroduirait la table dédiée qu'on vient de supprimer).
- ⚠️ Cette branche contient **un commit tooling** (lefthook `-f`) sans rapport avec thread-creator — intégré à la demande de l'auteur.

---

## 📋 Checklist

- [ ] 🇬🇧 After deploy, tell affected servers to re-select watched channels via `/config thread-creator` (single-`channel` config not migrated) / 🇫🇷 Après déploiement, prévenir les serveurs concernés de re-sélectionner leurs salons via `/config thread-creator` (config `channel` unique non reprise)
