### PR TITLE
fix: crash dans listener-loader quand aucun argument d'événement n'a .guild

### DIFF
--- a/src/core/loaders/listener-loader.ts
+++ b/src/core/loaders/listener-loader.ts
@@ -45,9 +45,10 @@ export function loadModuleEvents(client: Client, module: Module) {
 
     client.on(listener.eventType, (...args) => {
       const guildId =
-        args.find((arg) => !!arg.roles)?.id ||
-        args.find((arg) => !!arg?.guild).guild?.id ||
-        args.find((arg) => !!arg?.guildId);
+        args.find((arg) => !!arg?.guild)?.guild?.id ||
+        args.find((arg) => !!arg?.guildId)?.guildId ||
+        args.find((arg) => !!arg?.message?.guild)?.message?.guildId ||
+        args.find((arg) => !!arg?.message?.guildId)?.message?.guildId;
 
       if (guildId) {
         moduleService


### PR DESCRIPTION
### Bug

`TypeError: Cannot read properties of undefined (reading 'guild')` sur `src/core/loaders/listener-loader.ts:49` quand un événement Discord ne contient aucun argument avec une propriété `.guild` directe.

Cela arrivait avec `messageReactionAdd`/`messageReactionRemove` — l'objet `MessageReaction` n'a pas de `.guild` direct (il faut passer par `reaction.message.guild`).

### Fix

1. **Ajout de `?.`** après `args.find(...)` sur la ligne `.guild?.id` → empêche le crash quand aucun arg n'a `.guild`
2. **Ajout de `.guildId`** sur la ligne `args.find((arg) => !!arg?.guildId)` → retourne l'ID au lieu de l'objet
3. **Deux nouvelles fallbacks** `message.guild` et `message.guildId` → gère les événements comme `messageReactionAdd` où les infos sont dans `arg.message`
4. **Suppression** de la ligne `arg.roles` → `GuildMember.id` est le user ID, pas le guild ID (bug préexistant)