### PR TITLE
feat: module starboard personnalisable

### DIFF
--- a/src/core/loaders/listener-loader.ts
+++ b/src/core/loaders/listener-loader.ts
@@ -45,9 +45,10 @@ export function loadModuleEvents(client: Client, module: Module) {
 
     client.on(listener.eventType, (...args) => {
       const guildId =
-        args.find((arg) => !!arg.roles)?.id ||
-        args.find((arg) => !!arg?.guild).guild?.id ||
-        args.find((arg) => !!arg?.guildId);
+        args.find((arg) => !!arg?.guild)?.guild?.id ||
+        args.find((arg) => !!arg?.guildId)?.guildId ||
+        args.find((arg) => !!arg?.message?.guild)?.message?.guildId ||
+        args.find((arg) => !!arg?.message?.guildId)?.message?.guildId;
 
       if (guildId) {
         moduleService

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Client, Events } from "discord.js";
+import { Client, Events, Partials } from "discord.js";
 import coreModule from "./core/core.module.js";
 import { syncCommands } from "./core/loaders/command-loader.js";
 import {
@@ -26,6 +26,12 @@ const intents = modules.flatMap((module) => module.intents).filter((a) => !!a);
 
 export const client = new Client({
   intents: intents,
+  partials: [
+    Partials.Message,
+    Partials.Reaction,
+    Partials.User,
+    Partials.Channel,
+  ],
 });
 
 client.once(Events.ClientReady, async (readyClient) => {

--- a/src/modules/starboard/listeners/message-reaction-add.listener.ts
+++ b/src/modules/starboard/listeners/message-reaction-add.listener.ts
@@ -1,0 +1,27 @@
+import type {
+  MessageReaction,
+  PartialMessageReaction,
+  PartialUser,
+  User,
+} from "discord.js";
+import { declareEventListener } from "#lib/listener.js";
+import starboardService from "#modules/starboard/services/starboard.service.js";
+import type { StarboardConfigSchema } from "#modules/starboard/starboard.config.js";
+
+export default declareEventListener<
+  "messageReactionAdd",
+  StarboardConfigSchema
+>({
+  eventType: "messageReactionAdd",
+
+  async execute(
+    reaction: MessageReaction | PartialMessageReaction,
+    user: User | PartialUser,
+    _details: unknown,
+    config
+  ) {
+    if (!config) return;
+
+    await starboardService.handleReactionChange(reaction, user, config);
+  },
+});

--- a/src/modules/starboard/listeners/message-reaction-add.listener.ts
+++ b/src/modules/starboard/listeners/message-reaction-add.listener.ts
@@ -4,6 +4,7 @@ import type {
   PartialUser,
   User,
 } from "discord.js";
+import type { ConfigProvider } from "#lib/config.js";
 import { declareEventListener } from "#lib/listener.js";
 import starboardService from "#modules/starboard/services/starboard.service.js";
 import type { StarboardConfigSchema } from "#modules/starboard/starboard.config.js";
@@ -18,7 +19,7 @@ export default declareEventListener<
     reaction: MessageReaction | PartialMessageReaction,
     user: User | PartialUser,
     _details: unknown,
-    config
+    config: ConfigProvider<StarboardConfigSchema> | undefined
   ) {
     if (!config) return;
 

--- a/src/modules/starboard/listeners/message-reaction-remove.listener.ts
+++ b/src/modules/starboard/listeners/message-reaction-remove.listener.ts
@@ -1,0 +1,27 @@
+import type {
+  MessageReaction,
+  PartialMessageReaction,
+  PartialUser,
+  User,
+} from "discord.js";
+import { declareEventListener } from "#lib/listener.js";
+import starboardService from "#modules/starboard/services/starboard.service.js";
+import type { StarboardConfigSchema } from "#modules/starboard/starboard.config.js";
+
+export default declareEventListener<
+  "messageReactionRemove",
+  StarboardConfigSchema
+>({
+  eventType: "messageReactionRemove",
+
+  async execute(
+    reaction: MessageReaction | PartialMessageReaction,
+    user: User | PartialUser,
+    _details: unknown,
+    config
+  ) {
+    if (!config) return;
+
+    await starboardService.handleReactionChange(reaction, user, config);
+  },
+});

--- a/src/modules/starboard/listeners/message-reaction-remove.listener.ts
+++ b/src/modules/starboard/listeners/message-reaction-remove.listener.ts
@@ -4,6 +4,7 @@ import type {
   PartialUser,
   User,
 } from "discord.js";
+import type { ConfigProvider } from "#lib/config.js";
 import { declareEventListener } from "#lib/listener.js";
 import starboardService from "#modules/starboard/services/starboard.service.js";
 import type { StarboardConfigSchema } from "#modules/starboard/starboard.config.js";
@@ -18,7 +19,7 @@ export default declareEventListener<
     reaction: MessageReaction | PartialMessageReaction,
     user: User | PartialUser,
     _details: unknown,
-    config
+    config: ConfigProvider<StarboardConfigSchema> | undefined
   ) {
     if (!config) return;
 

--- a/src/modules/starboard/models/starboard.prisma
+++ b/src/modules/starboard/models/starboard.prisma
@@ -1,22 +1,3 @@
-
-// === Modèles de core/models/config.prisma ===
-model GuildConfiguration {
-  guildId String @id
-  data    Json
-}
-
-// === Modèles de core/models/modules.prisma ===
-model ModuleActivation {
-  moduleId String
-  guildId  String
-
-  activated        Boolean
-  activatedVersion String  @default("")
-
-  @@id([moduleId, guildId])
-}
-
-// === Modèles de modules/starboard/models/starboard.prisma ===
 model StarboardEntry {
   id                  String   @id @default(cuid())
   guildId             String

--- a/src/modules/starboard/models/starboard.prisma
+++ b/src/modules/starboard/models/starboard.prisma
@@ -5,7 +5,7 @@ model StarboardEntry {
   originalChannelId   String
   starboardMessageId  String
   starboardChannelId  String
-  reactionCount       Int      @default(0)
+  uniqueUserCount     Int      @default(0)
   reactions           Json     @default("[]")
   createdAt           DateTime @default(now())
   updatedAt           DateTime @updatedAt

--- a/src/modules/starboard/models/starboard.prisma
+++ b/src/modules/starboard/models/starboard.prisma
@@ -6,6 +6,7 @@ model StarboardEntry {
   starboardMessageId  String
   starboardChannelId  String
   reactionCount       Int      @default(0)
+  reactions           Json     @default("[]")
   createdAt           DateTime @default(now())
   updatedAt           DateTime @updatedAt
 

--- a/src/modules/starboard/services/starboard.service.ts
+++ b/src/modules/starboard/services/starboard.service.ts
@@ -125,7 +125,7 @@ class StarboardService implements Service {
     if (imageAttachments.size > 0) {
       container.addMediaGalleryComponents((gallery) =>
         gallery.addItems(
-          ...imageAttachments.map((a) => ({ media: { url: a.url } }))
+          ...imageAttachments.map((a) => ({ media: { url: a.url } })).values()
         )
       );
     }

--- a/src/modules/starboard/services/starboard.service.ts
+++ b/src/modules/starboard/services/starboard.service.ts
@@ -1,5 +1,4 @@
 import {
-  ButtonBuilder,
   ButtonStyle,
   ContainerBuilder,
   MessageFlags,
@@ -105,21 +104,23 @@ class StarboardService implements Service {
     const { timestamp } = this.buildNameAndTimestamp(referenced);
     const container = new ContainerBuilder();
 
-    container.addSectionComponents((section) =>
-      section
-        .addTextDisplayComponents((text) =>
-          text.setContent(`## ↪ ${referenced.author} · <t:${timestamp}:R>`)
-        )
-        .setThumbnailAccessory((thumbnail) =>
-          thumbnail.setURL(referenced.author.displayAvatarURL())
-        )
-    );
-
-    if (referenced.content) {
-      container.addTextDisplayComponents((text) =>
-        text.setContent(this.truncate(referenced.content))
+    container.addSectionComponents((section) => {
+      section.addTextDisplayComponents((text) =>
+        text.setContent(`## ↪ ${referenced.author} · <t:${timestamp}:R>\n`)
       );
-    }
+
+      if (referenced.content) {
+        section.addTextDisplayComponents((text) =>
+          text.setContent(this.truncate(referenced.content))
+        );
+      }
+
+      section.setThumbnailAccessory((thumbnail) =>
+        thumbnail.setURL(referenced.author.displayAvatarURL())
+      );
+
+      return section;
+    });
 
     const images = referenced.attachments.filter((a) =>
       a.contentType?.startsWith("image/")
@@ -131,27 +132,18 @@ class StarboardService implements Service {
 
     container.addSeparatorComponents((separator) => separator.setDivider(true));
 
-    if (attachmentText) {
-      container.addSectionComponents((section) =>
-        section
-          .addTextDisplayComponents((text) => text.setContent(attachmentText))
-          .setButtonAccessory((button) =>
-            button
-              .setStyle(ButtonStyle.Link)
-              .setURL(referenced.url)
-              .setLabel("Voir le message")
-          )
-      );
-    } else {
-      container.addActionRowComponents((row) =>
-        row.addComponents(
-          new ButtonBuilder()
+    container.addSectionComponents((section) =>
+      section
+        .addTextDisplayComponents((text) =>
+          text.setContent(attachmentText ?? "\u200b")
+        )
+        .setButtonAccessory((button) =>
+          button
             .setStyle(ButtonStyle.Link)
             .setURL(referenced.url)
             .setLabel("Voir le message")
         )
-      );
-    }
+    );
 
     return container;
   }
@@ -164,21 +156,23 @@ class StarboardService implements Service {
     const { timestamp } = this.buildNameAndTimestamp(message);
     const container = new ContainerBuilder();
 
-    container.addSectionComponents((section) =>
-      section
-        .addTextDisplayComponents((text) =>
-          text.setContent(`## ${message.author} · <t:${timestamp}:R>`)
-        )
-        .setThumbnailAccessory((thumbnail) =>
-          thumbnail.setURL(message.author.displayAvatarURL())
-        )
-    );
-
-    if (message.content) {
-      container.addTextDisplayComponents((text) =>
-        text.setContent(this.truncate(message.content))
+    container.addSectionComponents((section) => {
+      section.addTextDisplayComponents((text) =>
+        text.setContent(`## ${message.author} · <t:${timestamp}:R>\n`)
       );
-    }
+
+      if (message.content) {
+        section.addTextDisplayComponents((text) =>
+          text.setContent(this.truncate(message.content))
+        );
+      }
+
+      section.setThumbnailAccessory((thumbnail) =>
+        thumbnail.setURL(message.author.displayAvatarURL())
+      );
+
+      return section;
+    });
 
     const images = message.attachments.filter((a) =>
       a.contentType?.startsWith("image/")
@@ -191,13 +185,15 @@ class StarboardService implements Service {
       );
     }
 
-    container.setAccentColor(EMBED_COLORS[config.get("embedColor")]!);
+    container.setAccentColor(
+      EMBED_COLORS[config.get("embedColor")] ?? EMBED_COLORS["default"]
+    );
 
     container.addSeparatorComponents((separator) => separator.setDivider(true));
 
     if (metrics.emojis.length > 0) {
       container.addTextDisplayComponents((text) =>
-        text.setContent(`## ${this.buildReactionLine(metrics)}`)
+        text.setContent(`### ${this.buildReactionLine(metrics)}`)
       );
     }
 
@@ -274,13 +270,6 @@ class StarboardService implements Service {
         return;
       }
 
-      const metrics = await this.computeReactionMetrics(
-        message,
-        configuredEmojis,
-        config
-      );
-      const threshold = config.get("reactionCount");
-
       const existingEntry = await prisma.starboardEntry.findUnique({
         where: {
           guildId_originalMessageId: {
@@ -290,66 +279,64 @@ class StarboardService implements Service {
         },
       });
 
-      if (existingEntry) {
-        if (metrics.totalUniqueUsers >= threshold) {
-          await this.updateStarboardEntry(
-            existingEntry,
-            message,
-            metrics,
-            config
-          );
-        } else if (config.get("belowThresholdBehavior") === "remove") {
-          await this.removeStarboardEntry(existingEntry, guild);
-        } else {
-          await this.updateStarboardEntry(
-            existingEntry,
-            message,
-            metrics,
-            config
-          );
-        }
-      } else if (metrics.totalUniqueUsers >= threshold) {
-        try {
-          await this.createStarboardEntry(message, metrics, config);
-        } catch (error) {
-          if (
-            error instanceof Prisma.PrismaClientKnownRequestError &&
-            error.code === "P2002"
-          ) {
-            const existingEntry = await prisma.starboardEntry.findUnique({
-              where: {
-                guildId_originalMessageId: {
-                  guildId: guild.id,
-                  originalMessageId: message.id,
-                },
-              },
-            });
-            if (existingEntry) {
-              if (metrics.totalUniqueUsers >= threshold) {
-                await this.updateStarboardEntry(
-                  existingEntry,
-                  message,
-                  metrics,
-                  config
-                );
-              } else if (config.get("belowThresholdBehavior") === "remove") {
-                await this.removeStarboardEntry(existingEntry, guild);
-              } else {
-                await this.updateStarboardEntry(
-                  existingEntry,
-                  message,
-                  metrics,
-                  config
-                );
-              }
-            }
-          } else {
-            throw error;
-          }
-        }
-      }
+      const metrics = await this.computeReactionMetrics(
+        message,
+        configuredEmojis,
+        config
+      );
+
+      await this.applyMetrics(existingEntry, message, metrics, config);
     } catch (error) {
       logger.error({ err: error }, "Starboard reaction handler failed");
+    }
+  }
+
+  private async applyMetrics(
+    entry: {
+      id: string;
+      starboardMessageId: string;
+      starboardChannelId: string;
+    } | null,
+    message: Message,
+    metrics: ReactionMetrics,
+    config: ConfigProvider<StarboardConfigSchema>
+  ): Promise<void> {
+    const threshold = config.get("reactionCount");
+    const belowThreshold = config.get("belowThresholdBehavior");
+    const guild = message.guild!;
+
+    if (entry) {
+      if (metrics.totalUniqueUsers >= threshold || belowThreshold === "keep") {
+        await this.updateStarboardEntry(entry, message, metrics, config);
+      } else {
+        await this.removeStarboardEntry(entry, guild);
+      }
+      return;
+    }
+
+    if (metrics.totalUniqueUsers < threshold) return;
+
+    try {
+      await this.createStarboardEntry(message, metrics, config);
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2002"
+      ) {
+        const existingEntry = await prisma.starboardEntry.findUnique({
+          where: {
+            guildId_originalMessageId: {
+              guildId: guild.id,
+              originalMessageId: message.id,
+            },
+          },
+        });
+        if (existingEntry) {
+          await this.applyMetrics(existingEntry, message, metrics, config);
+        }
+      } else {
+        throw error;
+      }
     }
   }
 
@@ -387,7 +374,7 @@ class StarboardService implements Service {
           originalChannelId: message.channel.id,
           starboardMessageId: starboardMessage.id,
           starboardChannelId: starboardChannel.id,
-          reactionCount: metrics.totalUniqueUsers,
+          uniqueUserCount: metrics.totalUniqueUsers,
           reactions: metrics.emojis as unknown as Prisma.InputJsonValue[],
         },
       });
@@ -449,7 +436,7 @@ class StarboardService implements Service {
     await prisma.starboardEntry.update({
       where: { id: entry.id },
       data: {
-        reactionCount: metrics.totalUniqueUsers,
+        uniqueUserCount: metrics.totalUniqueUsers,
         reactions: metrics.emojis as unknown as Prisma.InputJsonValue[],
       },
     });

--- a/src/modules/starboard/services/starboard.service.ts
+++ b/src/modules/starboard/services/starboard.service.ts
@@ -81,6 +81,10 @@ class StarboardService implements Service {
     metrics: ReactionMetrics,
     config: ConfigProvider<StarboardConfigSchema>
   ) {
+    const description = message.content
+      ? `${message.content}\n\n${this.buildReactionLine(metrics)}`
+      : this.buildReactionLine(metrics);
+
     const embed = new EmbedBuilder()
       .setAuthor({
         name:
@@ -89,7 +93,7 @@ class StarboardService implements Service {
           message.author.username,
         iconURL: message.author.displayAvatarURL(),
       })
-      .setDescription(message.content || null)
+      .setDescription(description)
       .setColor(EMBED_COLORS[config.get("embedColor")]!)
       .setTimestamp(message.createdAt);
 
@@ -98,19 +102,15 @@ class StarboardService implements Service {
       embed.setThumbnail(firstAttachment.url);
     }
 
-    for (const metric of metrics.emojis) {
-      embed.addFields({
-        name: metric.emoji,
-        value: `× **${metric.count}**`,
-        inline: true,
-      });
-    }
-
     embed.setFooter({
       text: `${metrics.totalUniqueUsers} unique`,
     });
 
     return embed;
+  }
+
+  private buildReactionLine(metrics: ReactionMetrics): string {
+    return metrics.emojis.map((m) => `${m.emoji} **${m.count}**`).join(" | ");
   }
 
   private buildGoToMessageButton(message: Message) {

--- a/src/modules/starboard/services/starboard.service.ts
+++ b/src/modules/starboard/services/starboard.service.ts
@@ -101,8 +101,14 @@ class StarboardService implements Service {
       EMBED_COLORS[config.get("embedColor")]!
     );
 
-    container.addTextDisplayComponents((text) =>
-      text.setContent(`### ${authorName}\n<t:${timestamp}:R>`)
+    container.addSectionComponents((section) =>
+      section
+        .addTextDisplayComponents((text) =>
+          text.setContent(`### ${authorName}\n-# <t:${timestamp}:R>`)
+        )
+        .setThumbnailAccessory((thumbnail) =>
+          thumbnail.setURL(message.author.displayAvatarURL())
+        )
     );
 
     container.addSeparatorComponents((separator) => separator.setDivider(true));
@@ -113,10 +119,14 @@ class StarboardService implements Service {
       );
     }
 
-    const firstAttachment = message.attachments.first();
-    if (firstAttachment && firstAttachment.contentType?.startsWith("image/")) {
-      container.addTextDisplayComponents((text) =>
-        text.setContent(`[🖼️ Image](${firstAttachment.url})`)
+    const imageAttachments = message.attachments.filter((a) =>
+      a.contentType?.startsWith("image/")
+    );
+    if (imageAttachments.size > 0) {
+      container.addMediaGalleryComponents((gallery) =>
+        gallery.addItems(
+          ...imageAttachments.map((a) => ({ media: { url: a.url } }))
+        )
       );
     }
 
@@ -129,7 +139,7 @@ class StarboardService implements Service {
     container.addSectionComponents((section) =>
       section
         .addTextDisplayComponents((text) =>
-          text.setContent(`-# ${metrics.totalUniqueUsers} unique`)
+          text.setContent(`-# ${metrics.totalUniqueUsers} total`)
         )
         .setButtonAccessory((button) =>
           button
@@ -236,7 +246,6 @@ class StarboardService implements Service {
 
     const starboardMessage = await (channel as TextChannel).send({
       components: [container],
-      embeds: [...message.embeds],
       flags: MessageFlags.IsComponentsV2,
     });
 
@@ -289,7 +298,6 @@ class StarboardService implements Service {
     );
     await starboardMessage.edit({
       components: [container],
-      embeds: [...originalMessage.embeds],
       flags: MessageFlags.IsComponentsV2,
     });
 

--- a/src/modules/starboard/services/starboard.service.ts
+++ b/src/modules/starboard/services/starboard.service.ts
@@ -1,4 +1,5 @@
 import {
+  ButtonBuilder,
   ButtonStyle,
   ContainerBuilder,
   MessageFlags,
@@ -11,7 +12,7 @@ import {
   type User,
 } from "discord.js";
 import type { ConfigProvider } from "#lib/config.js";
-import prisma from "#lib/database.js";
+import prisma, { Prisma } from "#lib/database.js";
 import logger from "#lib/logger.js";
 import { declareService, type Service } from "#lib/service.js";
 import type { StarboardConfigSchema } from "#modules/starboard/starboard.config.js";
@@ -60,96 +61,184 @@ class StarboardService implements Service {
 
   private async computeReactionMetrics(
     message: Message,
-    configuredEmojis: string[]
+    configuredEmojis: string[],
+    config: ConfigProvider<StarboardConfigSchema>
   ): Promise<ReactionMetrics> {
     const emojis: ReactionMetric[] = [];
     const uniqueUsers = new Set<string>();
+    const selfStar = config.get("selfStar");
 
     for (const [, reaction] of message.reactions.cache) {
       if (!this.matchEmoji(reaction.emoji, configuredEmojis)) continue;
 
+      const users = await reaction.users.fetch();
+      const filteredUsers = [...users.keys()].filter(
+        (id) => selfStar || id !== message.author.id
+      );
+
+      filteredUsers.forEach((id) => uniqueUsers.add(id));
       emojis.push({
         emoji: this.formatEmoji(reaction.emoji),
-        count: reaction.count,
+        count: filteredUsers.length,
       });
-
-      const users = await reaction.users.fetch();
-      for (const userId of users.keys()) {
-        uniqueUsers.add(userId);
-      }
     }
 
     return { emojis, totalUniqueUsers: uniqueUsers.size };
   }
 
   private buildReactionLine(metrics: ReactionMetrics): string {
-    return metrics.emojis.map((m) => `${m.emoji} **${m.count}**`).join(" | ");
+    if (metrics.emojis.length === 0) return "";
+    return metrics.emojis.map((m) => `${m.emoji} **${m.count}**`).join(" · ");
   }
 
-  private buildStarboardContainer(
-    message: Message,
-    metrics: ReactionMetrics,
-    config: ConfigProvider<StarboardConfigSchema>
-  ): ContainerBuilder {
-    const authorName =
-      message.member?.displayName ??
-      message.author.globalName ??
-      message.author.username;
-    const timestamp = Math.floor(message.createdAt.getTime() / 1000);
+  private truncate(text: string, max = 1000): string {
+    if (text.length <= max) return text;
+    return text.slice(0, max - 3) + "...";
+  }
 
-    const container = new ContainerBuilder().setAccentColor(
-      EMBED_COLORS[config.get("embedColor")]!
-    );
+  private buildNameAndTimestamp(message: Message) {
+    const timestamp = Math.floor(message.createdAt.getTime() / 1000);
+    return { timestamp };
+  }
+
+  private buildReplyContainer(referenced: Message): ContainerBuilder {
+    const { timestamp } = this.buildNameAndTimestamp(referenced);
+    const container = new ContainerBuilder();
 
     container.addSectionComponents((section) =>
       section
         .addTextDisplayComponents((text) =>
-          text.setContent(`### ${authorName}\n-# <t:${timestamp}:R>`)
+          text.setContent(`## ↪ ${referenced.author} · <t:${timestamp}:R>`)
+        )
+        .setThumbnailAccessory((thumbnail) =>
+          thumbnail.setURL(referenced.author.displayAvatarURL())
+        )
+    );
+
+    if (referenced.content) {
+      container.addTextDisplayComponents((text) =>
+        text.setContent(this.truncate(referenced.content))
+      );
+    }
+
+    const images = referenced.attachments.filter((a) =>
+      a.contentType?.startsWith("image/")
+    );
+    const attachmentText =
+      images.size > 0
+        ? `🖼️ ${images.size} pièce${images.size > 1 ? "s" : ""} jointe${images.size > 1 ? "s" : ""}`
+        : null;
+
+    container.addSeparatorComponents((separator) => separator.setDivider(true));
+
+    if (attachmentText) {
+      container.addSectionComponents((section) =>
+        section
+          .addTextDisplayComponents((text) => text.setContent(attachmentText))
+          .setButtonAccessory((button) =>
+            button
+              .setStyle(ButtonStyle.Link)
+              .setURL(referenced.url)
+              .setLabel("Voir le message")
+          )
+      );
+    } else {
+      container.addActionRowComponents((row) =>
+        row.addComponents(
+          new ButtonBuilder()
+            .setStyle(ButtonStyle.Link)
+            .setURL(referenced.url)
+            .setLabel("Voir le message")
+        )
+      );
+    }
+
+    return container;
+  }
+
+  private async buildMainContainer(
+    message: Message,
+    metrics: ReactionMetrics,
+    config: ConfigProvider<StarboardConfigSchema>
+  ): Promise<ContainerBuilder> {
+    const { timestamp } = this.buildNameAndTimestamp(message);
+    const container = new ContainerBuilder();
+
+    container.addSectionComponents((section) =>
+      section
+        .addTextDisplayComponents((text) =>
+          text.setContent(`## ${message.author} · <t:${timestamp}:R>`)
         )
         .setThumbnailAccessory((thumbnail) =>
           thumbnail.setURL(message.author.displayAvatarURL())
         )
     );
 
-    container.addSeparatorComponents((separator) => separator.setDivider(true));
-
     if (message.content) {
       container.addTextDisplayComponents((text) =>
-        text.setContent(message.content)
+        text.setContent(this.truncate(message.content))
       );
     }
 
-    const imageAttachments = message.attachments.filter((a) =>
+    const images = message.attachments.filter((a) =>
       a.contentType?.startsWith("image/")
     );
-    if (imageAttachments.size > 0) {
+    if (images.size > 0) {
       container.addMediaGalleryComponents((gallery) =>
         gallery.addItems(
-          ...imageAttachments.map((a) => ({ media: { url: a.url } })).values()
+          ...images.map((a) => ({ media: { url: a.url } })).values()
         )
       );
     }
 
-    container.addTextDisplayComponents((text) =>
-      text.setContent(this.buildReactionLine(metrics))
-    );
+    container.setAccentColor(EMBED_COLORS[config.get("embedColor")]!);
 
     container.addSeparatorComponents((separator) => separator.setDivider(true));
+
+    if (metrics.emojis.length > 0) {
+      container.addTextDisplayComponents((text) =>
+        text.setContent(`## ${this.buildReactionLine(metrics)}`)
+      );
+    }
 
     container.addSectionComponents((section) =>
       section
         .addTextDisplayComponents((text) =>
-          text.setContent(`-# ${metrics.totalUniqueUsers} total`)
+          text.setContent(
+            `-# **${metrics.totalUniqueUsers}** unique${
+              metrics.totalUniqueUsers > 1 ? "s" : ""
+            }`
+          )
         )
         .setButtonAccessory((button) =>
           button
             .setStyle(ButtonStyle.Link)
             .setURL(message.url)
-            .setLabel("Aller au message")
+            .setLabel("Voir le message")
         )
     );
 
     return container;
+  }
+
+  private async buildComponents(
+    message: Message,
+    metrics: ReactionMetrics,
+    config: ConfigProvider<StarboardConfigSchema>
+  ): Promise<ContainerBuilder[]> {
+    const components: ContainerBuilder[] = [];
+
+    if (message.reference?.messageId) {
+      try {
+        const referenced = await message.fetchReference();
+        components.push(this.buildReplyContainer(referenced));
+      } catch {
+        // referenced message deleted or inaccessible
+      }
+    }
+
+    components.push(await this.buildMainContainer(message, metrics, config));
+    return components;
   }
 
   async handleReactionChange(
@@ -158,7 +247,8 @@ class StarboardService implements Service {
     config: ConfigProvider<StarboardConfigSchema>
   ): Promise<void> {
     try {
-      if (reaction.partial || user.partial) return;
+      if (reaction.partial) reaction = await reaction.fetch();
+      if (user.partial) user = await user.fetch();
 
       const message = await reaction.message.fetch();
       const guild = message.guild;
@@ -186,7 +276,8 @@ class StarboardService implements Service {
 
       const metrics = await this.computeReactionMetrics(
         message,
-        configuredEmojis
+        configuredEmojis,
+        config
       );
       const threshold = config.get("reactionCount");
 
@@ -218,12 +309,47 @@ class StarboardService implements Service {
           );
         }
       } else if (metrics.totalUniqueUsers >= threshold) {
-        await this.createStarboardEntry(message, metrics, config);
+        try {
+          await this.createStarboardEntry(message, metrics, config);
+        } catch (error) {
+          if (
+            error instanceof Prisma.PrismaClientKnownRequestError &&
+            error.code === "P2002"
+          ) {
+            const existingEntry = await prisma.starboardEntry.findUnique({
+              where: {
+                guildId_originalMessageId: {
+                  guildId: guild.id,
+                  originalMessageId: message.id,
+                },
+              },
+            });
+            if (existingEntry) {
+              if (metrics.totalUniqueUsers >= threshold) {
+                await this.updateStarboardEntry(
+                  existingEntry,
+                  message,
+                  metrics,
+                  config
+                );
+              } else if (config.get("belowThresholdBehavior") === "remove") {
+                await this.removeStarboardEntry(existingEntry, guild);
+              } else {
+                await this.updateStarboardEntry(
+                  existingEntry,
+                  message,
+                  metrics,
+                  config
+                );
+              }
+            }
+          } else {
+            throw error;
+          }
+        }
       }
     } catch (error) {
-      logger.error(
-        `Erreur dans le StarboardService.handleReactionChange : ${error}`
-      );
+      logger.error({ err: error }, "Starboard reaction handler failed");
     }
   }
 
@@ -242,10 +368,10 @@ class StarboardService implements Service {
     if (!channel?.isTextBased()) return;
     if (!("send" in channel)) return;
 
-    const container = this.buildStarboardContainer(message, metrics, config);
+    const components = await this.buildComponents(message, metrics, config);
 
     const starboardMessage = await (channel as TextChannel).send({
-      components: [container],
+      components,
       flags: MessageFlags.IsComponentsV2,
     });
 
@@ -253,17 +379,22 @@ class StarboardService implements Service {
       await starboardMessage.react(metric.emoji).catch(() => {});
     }
 
-    await prisma.starboardEntry.create({
-      data: {
-        guildId: guild.id,
-        originalMessageId: message.id,
-        originalChannelId: message.channel.id,
-        starboardMessageId: starboardMessage.id,
-        starboardChannelId: starboardChannel.id,
-        reactionCount: metrics.totalUniqueUsers,
-        reactions: metrics.emojis as any,
-      },
-    });
+    try {
+      await prisma.starboardEntry.create({
+        data: {
+          guildId: guild.id,
+          originalMessageId: message.id,
+          originalChannelId: message.channel.id,
+          starboardMessageId: starboardMessage.id,
+          starboardChannelId: starboardChannel.id,
+          reactionCount: metrics.totalUniqueUsers,
+          reactions: metrics.emojis as unknown as Prisma.InputJsonValue[],
+        },
+      });
+    } catch (error) {
+      await starboardMessage.delete().catch(() => {});
+      throw error;
+    }
   }
 
   private async updateStarboardEntry(
@@ -291,13 +422,13 @@ class StarboardService implements Service {
       return;
     }
 
-    const container = this.buildStarboardContainer(
+    const components = await this.buildComponents(
       originalMessage,
       metrics,
       config
     );
     await starboardMessage.edit({
-      components: [container],
+      components,
       flags: MessageFlags.IsComponentsV2,
     });
 
@@ -319,7 +450,7 @@ class StarboardService implements Service {
       where: { id: entry.id },
       data: {
         reactionCount: metrics.totalUniqueUsers,
-        reactions: metrics.emojis as any,
+        reactions: metrics.emojis as unknown as Prisma.InputJsonValue[],
       },
     });
   }

--- a/src/modules/starboard/services/starboard.service.ts
+++ b/src/modules/starboard/services/starboard.service.ts
@@ -1,4 +1,7 @@
 import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
   EmbedBuilder,
   type Message,
   type MessageReaction,
@@ -55,12 +58,13 @@ class StarboardService implements Service {
   ) {
     const embed = new EmbedBuilder()
       .setAuthor({
-        name: message.author.tag,
+        name:
+          message.member?.displayName ??
+          message.author.globalName ??
+          message.author.username,
         iconURL: message.author.displayAvatarURL(),
       })
-      .setDescription(
-        `${message.content || ""}\n\n[Aller au message](${message.url})`
-      )
+      .setDescription(message.content || null)
       .setColor(EMBED_COLORS[config.get("embedColor")]!)
       .setTimestamp(message.createdAt);
 
@@ -76,14 +80,22 @@ class StarboardService implements Service {
     return embed;
   }
 
+  private buildGoToMessageButton(message: Message) {
+    return new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setStyle(ButtonStyle.Link)
+        .setURL(message.url)
+        .setLabel("Aller au message")
+    );
+  }
+
   async handleReactionChange(
     reaction: MessageReaction | PartialMessageReaction,
     user: User | PartialUser,
     config: ConfigProvider<StarboardConfigSchema>
   ): Promise<void> {
     try {
-      if (reaction.partial) return;
-      if (user.partial) return;
+      if (reaction.partial || user.partial) return;
 
       const message = await reaction.message.fetch();
       const guild = message.guild;
@@ -160,9 +172,17 @@ class StarboardService implements Service {
       config
     );
 
+    const goToButton = this.buildGoToMessageButton(message);
+
     const starboardMessage = await (channel as TextChannel).send({
       embeds: [starboardEmbed, ...message.embeds],
+      components: [goToButton],
     });
+
+    const firstEmoji = config.get("reactionEmojis")[0];
+    if (firstEmoji) {
+      await starboardMessage.react(firstEmoji).catch(() => {});
+    }
 
     await prisma.starboardEntry.create({
       data: {
@@ -177,9 +197,7 @@ class StarboardService implements Service {
   }
 
   private async updateStarboardEntry(
-    entry: {
-      id: string;
-    },
+    entry: { id: string },
     newCount: number
   ): Promise<void> {
     await prisma.starboardEntry.update({

--- a/src/modules/starboard/services/starboard.service.ts
+++ b/src/modules/starboard/services/starboard.service.ts
@@ -3,6 +3,7 @@ import {
   ButtonBuilder,
   ButtonStyle,
   EmbedBuilder,
+  type Guild,
   type Message,
   type MessageReaction,
   type PartialMessageReaction,
@@ -15,6 +16,16 @@ import prisma from "#lib/database.js";
 import logger from "#lib/logger.js";
 import { declareService, type Service } from "#lib/service.js";
 import type { StarboardConfigSchema } from "#modules/starboard/starboard.config.js";
+
+interface ReactionMetric {
+  emoji: string;
+  count: number;
+}
+
+interface ReactionMetrics {
+  emojis: ReactionMetric[];
+  totalUniqueUsers: number;
+}
 
 const EMBED_COLORS: Record<string, number> = {
   default: 0x2b2d31,
@@ -41,19 +52,33 @@ class StarboardService implements Service {
     });
   }
 
-  computeStarCount(message: Message, configuredEmojis: string[]): number {
-    let total = 0;
+  private async computeReactionMetrics(
+    message: Message,
+    configuredEmojis: string[]
+  ): Promise<ReactionMetrics> {
+    const emojis: ReactionMetric[] = [];
+    const uniqueUsers = new Set<string>();
+
     for (const [, reaction] of message.reactions.cache) {
-      if (this.matchEmoji(reaction.emoji, configuredEmojis)) {
-        total += reaction.count;
+      if (!this.matchEmoji(reaction.emoji, configuredEmojis)) continue;
+
+      emojis.push({
+        emoji: reaction.emoji.toString(),
+        count: reaction.count,
+      });
+
+      const users = await reaction.users.fetch();
+      for (const userId of users.keys()) {
+        uniqueUsers.add(userId);
       }
     }
-    return total;
+
+    return { emojis, totalUniqueUsers: uniqueUsers.size };
   }
 
   private buildStarboardEmbed(
     message: Message,
-    reactionCount: number,
+    metrics: ReactionMetrics,
     config: ConfigProvider<StarboardConfigSchema>
   ) {
     const embed = new EmbedBuilder()
@@ -73,8 +98,16 @@ class StarboardService implements Service {
       embed.setThumbnail(firstAttachment.url);
     }
 
+    for (const metric of metrics.emojis) {
+      embed.addFields({
+        name: metric.emoji,
+        value: `× **${metric.count}**`,
+        inline: true,
+      });
+    }
+
     embed.setFooter({
-      text: `${reactionCount} ⭐`,
+      text: `${metrics.totalUniqueUsers} unique`,
     });
 
     return embed;
@@ -121,7 +154,10 @@ class StarboardService implements Service {
         return;
       }
 
-      const totalStars = this.computeStarCount(message, configuredEmojis);
+      const metrics = await this.computeReactionMetrics(
+        message,
+        configuredEmojis
+      );
       const threshold = config.get("reactionCount");
 
       const existingEntry = await prisma.starboardEntry.findUnique({
@@ -134,15 +170,25 @@ class StarboardService implements Service {
       });
 
       if (existingEntry) {
-        if (totalStars >= threshold) {
-          await this.updateStarboardEntry(existingEntry, totalStars);
+        if (metrics.totalUniqueUsers >= threshold) {
+          await this.updateStarboardEntry(
+            existingEntry,
+            message,
+            metrics,
+            config
+          );
         } else if (config.get("belowThresholdBehavior") === "remove") {
-          await this.removeStarboardEntry(existingEntry);
+          await this.removeStarboardEntry(existingEntry, guild);
         } else {
-          await this.updateStarboardEntry(existingEntry, totalStars);
+          await this.updateStarboardEntry(
+            existingEntry,
+            message,
+            metrics,
+            config
+          );
         }
-      } else if (totalStars >= threshold) {
-        await this.createStarboardEntry(message, totalStars, config);
+      } else if (metrics.totalUniqueUsers >= threshold) {
+        await this.createStarboardEntry(message, metrics, config);
       }
     } catch (error) {
       logger.error(
@@ -153,7 +199,7 @@ class StarboardService implements Service {
 
   private async createStarboardEntry(
     message: Message,
-    reactionCount: number,
+    metrics: ReactionMetrics,
     config: ConfigProvider<StarboardConfigSchema>
   ): Promise<void> {
     const starboardChannel = config.get("starboardChannel");
@@ -166,12 +212,7 @@ class StarboardService implements Service {
     if (!channel?.isTextBased()) return;
     if (!("send" in channel)) return;
 
-    const starboardEmbed = this.buildStarboardEmbed(
-      message,
-      reactionCount,
-      config
-    );
-
+    const starboardEmbed = this.buildStarboardEmbed(message, metrics, config);
     const goToButton = this.buildGoToMessageButton(message);
 
     const starboardMessage = await (channel as TextChannel).send({
@@ -179,9 +220,8 @@ class StarboardService implements Service {
       components: [goToButton],
     });
 
-    const firstEmoji = config.get("reactionEmojis")[0];
-    if (firstEmoji) {
-      await starboardMessage.react(firstEmoji).catch(() => {});
+    for (const metric of metrics.emojis) {
+      await starboardMessage.react(metric.emoji).catch(() => {});
     }
 
     await prisma.starboardEntry.create({
@@ -191,22 +231,93 @@ class StarboardService implements Service {
         originalChannelId: message.channel.id,
         starboardMessageId: starboardMessage.id,
         starboardChannelId: starboardChannel.id,
-        reactionCount,
+        reactionCount: metrics.totalUniqueUsers,
+        reactions: metrics.emojis as any,
       },
     });
   }
 
   private async updateStarboardEntry(
-    entry: { id: string },
-    newCount: number
+    entry: {
+      id: string;
+      starboardMessageId: string;
+      starboardChannelId: string;
+    },
+    originalMessage: Message,
+    metrics: ReactionMetrics,
+    config: ConfigProvider<StarboardConfigSchema>
   ): Promise<void> {
+    const guild = originalMessage.guild;
+    if (!guild) return;
+
+    const channel = await guild.channels.fetch(entry.starboardChannelId);
+    if (!channel?.isTextBased()) return;
+
+    let starboardMessage: Message;
+    try {
+      starboardMessage = await (channel as TextChannel).messages.fetch(
+        entry.starboardMessageId
+      );
+    } catch {
+      return;
+    }
+
+    const starboardEmbed = this.buildStarboardEmbed(
+      originalMessage,
+      metrics,
+      config
+    );
+    await starboardMessage.edit({
+      embeds: [starboardEmbed, ...originalMessage.embeds],
+    });
+
+    const currentReactions = starboardMessage.reactions.cache;
+    for (const metric of metrics.emojis) {
+      if (!currentReactions.has(metric.emoji)) {
+        await starboardMessage.react(metric.emoji).catch(() => {});
+      }
+    }
+
+    for (const [, reaction] of currentReactions) {
+      const emojiString = reaction.emoji.toString();
+      if (!metrics.emojis.some((m) => m.emoji === emojiString)) {
+        await reaction.remove().catch(() => {});
+      }
+    }
+
     await prisma.starboardEntry.update({
       where: { id: entry.id },
-      data: { reactionCount: newCount },
+      data: {
+        reactionCount: metrics.totalUniqueUsers,
+        reactions: metrics.emojis as any,
+      },
     });
   }
 
-  private async removeStarboardEntry(entry: { id: string }): Promise<void> {
+  private async removeStarboardEntry(
+    entry: {
+      starboardMessageId: string;
+      starboardChannelId: string;
+      id: string;
+    },
+    guild: Guild
+  ): Promise<void> {
+    try {
+      const channel = await guild.channels.fetch(entry.starboardChannelId);
+      if (channel?.isTextBased()) {
+        try {
+          const msg = await (channel as TextChannel).messages.fetch(
+            entry.starboardMessageId
+          );
+          await msg.delete();
+        } catch {
+          // message already deleted or inaccessible
+        }
+      }
+    } catch {
+      // channel inaccessible
+    }
+
     await prisma.starboardEntry.delete({
       where: { id: entry.id },
     });

--- a/src/modules/starboard/services/starboard.service.ts
+++ b/src/modules/starboard/services/starboard.service.ts
@@ -1,8 +1,7 @@
 import {
-  ActionRowBuilder,
-  ButtonBuilder,
   ButtonStyle,
-  EmbedBuilder,
+  ContainerBuilder,
+  MessageFlags,
   type Guild,
   type Message,
   type MessageReaction,
@@ -83,50 +82,64 @@ class StarboardService implements Service {
     return { emojis, totalUniqueUsers: uniqueUsers.size };
   }
 
-  private buildStarboardEmbed(
-    message: Message,
-    metrics: ReactionMetrics,
-    config: ConfigProvider<StarboardConfigSchema>
-  ) {
-    const description = message.content
-      ? `${message.content}\n\n${this.buildReactionLine(metrics)}`
-      : this.buildReactionLine(metrics);
-
-    const embed = new EmbedBuilder()
-      .setAuthor({
-        name:
-          message.member?.displayName ??
-          message.author.globalName ??
-          message.author.username,
-        iconURL: message.author.displayAvatarURL(),
-      })
-      .setDescription(description)
-      .setColor(EMBED_COLORS[config.get("embedColor")]!)
-      .setTimestamp(message.createdAt);
-
-    const firstAttachment = message.attachments.first();
-    if (firstAttachment && firstAttachment.contentType?.startsWith("image/")) {
-      embed.setThumbnail(firstAttachment.url);
-    }
-
-    embed.setFooter({
-      text: `${metrics.totalUniqueUsers} unique`,
-    });
-
-    return embed;
-  }
-
   private buildReactionLine(metrics: ReactionMetrics): string {
     return metrics.emojis.map((m) => `${m.emoji} **${m.count}**`).join(" | ");
   }
 
-  private buildGoToMessageButton(message: Message) {
-    return new ActionRowBuilder<ButtonBuilder>().addComponents(
-      new ButtonBuilder()
-        .setStyle(ButtonStyle.Link)
-        .setURL(message.url)
-        .setLabel("Aller au message")
+  private buildStarboardContainer(
+    message: Message,
+    metrics: ReactionMetrics,
+    config: ConfigProvider<StarboardConfigSchema>
+  ): ContainerBuilder {
+    const authorName =
+      message.member?.displayName ??
+      message.author.globalName ??
+      message.author.username;
+    const timestamp = Math.floor(message.createdAt.getTime() / 1000);
+
+    const container = new ContainerBuilder().setAccentColor(
+      EMBED_COLORS[config.get("embedColor")]!
     );
+
+    container.addTextDisplayComponents((text) =>
+      text.setContent(`### ${authorName}\n<t:${timestamp}:R>`)
+    );
+
+    container.addSeparatorComponents((separator) => separator.setDivider(true));
+
+    if (message.content) {
+      container.addTextDisplayComponents((text) =>
+        text.setContent(message.content)
+      );
+    }
+
+    const firstAttachment = message.attachments.first();
+    if (firstAttachment && firstAttachment.contentType?.startsWith("image/")) {
+      container.addTextDisplayComponents((text) =>
+        text.setContent(`[🖼️ Image](${firstAttachment.url})`)
+      );
+    }
+
+    container.addTextDisplayComponents((text) =>
+      text.setContent(this.buildReactionLine(metrics))
+    );
+
+    container.addSeparatorComponents((separator) => separator.setDivider(true));
+
+    container.addSectionComponents((section) =>
+      section
+        .addTextDisplayComponents((text) =>
+          text.setContent(`-# ${metrics.totalUniqueUsers} unique`)
+        )
+        .setButtonAccessory((button) =>
+          button
+            .setStyle(ButtonStyle.Link)
+            .setURL(message.url)
+            .setLabel("Aller au message")
+        )
+    );
+
+    return container;
   }
 
   async handleReactionChange(
@@ -219,12 +232,12 @@ class StarboardService implements Service {
     if (!channel?.isTextBased()) return;
     if (!("send" in channel)) return;
 
-    const starboardEmbed = this.buildStarboardEmbed(message, metrics, config);
-    const goToButton = this.buildGoToMessageButton(message);
+    const container = this.buildStarboardContainer(message, metrics, config);
 
     const starboardMessage = await (channel as TextChannel).send({
-      embeds: [starboardEmbed, ...message.embeds],
-      components: [goToButton],
+      components: [container],
+      embeds: [...message.embeds],
+      flags: MessageFlags.IsComponentsV2,
     });
 
     for (const metric of metrics.emojis) {
@@ -269,13 +282,15 @@ class StarboardService implements Service {
       return;
     }
 
-    const starboardEmbed = this.buildStarboardEmbed(
+    const container = this.buildStarboardContainer(
       originalMessage,
       metrics,
       config
     );
     await starboardMessage.edit({
-      embeds: [starboardEmbed, ...originalMessage.embeds],
+      components: [container],
+      embeds: [...originalMessage.embeds],
+      flags: MessageFlags.IsComponentsV2,
     });
 
     const currentReactions = starboardMessage.reactions.cache;

--- a/src/modules/starboard/services/starboard.service.ts
+++ b/src/modules/starboard/services/starboard.service.ts
@@ -1,0 +1,198 @@
+import {
+  EmbedBuilder,
+  type Message,
+  type MessageReaction,
+  type PartialMessageReaction,
+  type PartialUser,
+  type TextChannel,
+  type User,
+} from "discord.js";
+import type { ConfigProvider } from "#lib/config.js";
+import prisma from "#lib/database.js";
+import logger from "#lib/logger.js";
+import { declareService, type Service } from "#lib/service.js";
+import type { StarboardConfigSchema } from "#modules/starboard/starboard.config.js";
+
+const EMBED_COLORS: Record<string, number> = {
+  default: 0x2b2d31,
+  gold: 0xffd700,
+  blue: 0x3498db,
+  green: 0x2ecc71,
+  red: 0xe74c3c,
+};
+
+class StarboardService implements Service {
+  matchEmoji(
+    emoji: MessageReaction["emoji"],
+    configuredEmojis: string[]
+  ): boolean {
+    return configuredEmojis.some((configured) => {
+      const customMatch = configured.match(/^<a?:\w+:(\d+)>$/);
+      if (customMatch) {
+        return emoji.id === customMatch[1];
+      }
+      if (/^\d+$/.test(configured)) {
+        return emoji.id === configured;
+      }
+      return emoji.name === configured;
+    });
+  }
+
+  computeStarCount(message: Message, configuredEmojis: string[]): number {
+    let total = 0;
+    for (const [, reaction] of message.reactions.cache) {
+      if (this.matchEmoji(reaction.emoji, configuredEmojis)) {
+        total += reaction.count;
+      }
+    }
+    return total;
+  }
+
+  private buildStarboardEmbed(
+    message: Message,
+    reactionCount: number,
+    config: ConfigProvider<StarboardConfigSchema>
+  ) {
+    const embed = new EmbedBuilder()
+      .setAuthor({
+        name: message.author.tag,
+        iconURL: message.author.displayAvatarURL(),
+      })
+      .setDescription(
+        `${message.content || ""}\n\n[Aller au message](${message.url})`
+      )
+      .setColor(EMBED_COLORS[config.get("embedColor")]!)
+      .setTimestamp(message.createdAt);
+
+    const firstAttachment = message.attachments.first();
+    if (firstAttachment && firstAttachment.contentType?.startsWith("image/")) {
+      embed.setThumbnail(firstAttachment.url);
+    }
+
+    embed.setFooter({
+      text: `${reactionCount} ⭐`,
+    });
+
+    return embed;
+  }
+
+  async handleReactionChange(
+    reaction: MessageReaction | PartialMessageReaction,
+    user: User | PartialUser,
+    config: ConfigProvider<StarboardConfigSchema>
+  ): Promise<void> {
+    try {
+      if (reaction.partial) return;
+      if (user.partial) return;
+
+      const message = await reaction.message.fetch();
+      const guild = message.guild;
+      if (!guild) return;
+
+      const starboardChannel = config.get("starboardChannel");
+      if (!starboardChannel) return;
+      if (message.channel.id === starboardChannel.id) return;
+
+      const configuredEmojis = config.get("reactionEmojis");
+      if (!this.matchEmoji(reaction.emoji, configuredEmojis)) return;
+
+      if (!config.get("selfStar") && user.id === message.author.id) return;
+
+      if (config.get("ignoreBotMessages") && message.author.bot) return;
+
+      const allowedChannels = config.get("allowedChannels");
+      if (
+        allowedChannels &&
+        allowedChannels.length > 0 &&
+        !allowedChannels.some((c) => c.id === message.channel.id)
+      ) {
+        return;
+      }
+
+      const totalStars = this.computeStarCount(message, configuredEmojis);
+      const threshold = config.get("reactionCount");
+
+      const existingEntry = await prisma.starboardEntry.findUnique({
+        where: {
+          guildId_originalMessageId: {
+            guildId: guild.id,
+            originalMessageId: message.id,
+          },
+        },
+      });
+
+      if (existingEntry) {
+        if (totalStars >= threshold) {
+          await this.updateStarboardEntry(existingEntry, totalStars);
+        } else if (config.get("belowThresholdBehavior") === "remove") {
+          await this.removeStarboardEntry(existingEntry);
+        } else {
+          await this.updateStarboardEntry(existingEntry, totalStars);
+        }
+      } else if (totalStars >= threshold) {
+        await this.createStarboardEntry(message, totalStars, config);
+      }
+    } catch (error) {
+      logger.error(
+        `Erreur dans le StarboardService.handleReactionChange : ${error}`
+      );
+    }
+  }
+
+  private async createStarboardEntry(
+    message: Message,
+    reactionCount: number,
+    config: ConfigProvider<StarboardConfigSchema>
+  ): Promise<void> {
+    const starboardChannel = config.get("starboardChannel");
+    if (!starboardChannel) return;
+
+    const guild = message.guild;
+    if (!guild) return;
+
+    const channel = await guild.channels.fetch(starboardChannel.id);
+    if (!channel?.isTextBased()) return;
+    if (!("send" in channel)) return;
+
+    const starboardEmbed = this.buildStarboardEmbed(
+      message,
+      reactionCount,
+      config
+    );
+
+    const starboardMessage = await (channel as TextChannel).send({
+      embeds: [starboardEmbed, ...message.embeds],
+    });
+
+    await prisma.starboardEntry.create({
+      data: {
+        guildId: guild.id,
+        originalMessageId: message.id,
+        originalChannelId: message.channel.id,
+        starboardMessageId: starboardMessage.id,
+        starboardChannelId: starboardChannel.id,
+        reactionCount,
+      },
+    });
+  }
+
+  private async updateStarboardEntry(
+    entry: {
+      id: string;
+    },
+    newCount: number
+  ): Promise<void> {
+    await prisma.starboardEntry.update({
+      where: { id: entry.id },
+      data: { reactionCount: newCount },
+    });
+  }
+
+  private async removeStarboardEntry(entry: { id: string }): Promise<void> {
+    await prisma.starboardEntry.delete({
+      where: { id: entry.id },
+    });
+  }
+}
+
+export default declareService(new StarboardService());

--- a/src/modules/starboard/services/starboard.service.ts
+++ b/src/modules/starboard/services/starboard.service.ts
@@ -52,6 +52,13 @@ class StarboardService implements Service {
     });
   }
 
+  private formatEmoji(emoji: MessageReaction["emoji"]): string {
+    if (emoji.id) {
+      return `<${emoji.animated ? "a" : ""}:${emoji.name}:${emoji.id}>`;
+    }
+    return emoji.name!;
+  }
+
   private async computeReactionMetrics(
     message: Message,
     configuredEmojis: string[]
@@ -63,7 +70,7 @@ class StarboardService implements Service {
       if (!this.matchEmoji(reaction.emoji, configuredEmojis)) continue;
 
       emojis.push({
-        emoji: reaction.emoji.toString(),
+        emoji: this.formatEmoji(reaction.emoji),
         count: reaction.count,
       });
 

--- a/src/modules/starboard/starboard.config.ts
+++ b/src/modules/starboard/starboard.config.ts
@@ -1,0 +1,56 @@
+import { ConfigType, type ConfigSchema } from "#lib/config.js";
+
+export const starboardConfigSchema = {
+  starboardChannel: {
+    name: "Salon starboard",
+    description: "Salon où les messages starboardés sont repostés.",
+    type: ConfigType.CHANNEL,
+  },
+  reactionEmojis: {
+    name: "Émojis déclencheurs",
+    description:
+      "Émojis qui déclenchent le starboard (unicode ou custom <:name:id>).",
+    type: [ConfigType.STRING],
+    defaultValue: ["⭐"],
+  },
+  reactionCount: {
+    name: "Seuil de réactions",
+    description: "Nombre minimum de réactions pour starboarder un message.",
+    type: ConfigType.NUMBER,
+    defaultValue: 3,
+  },
+  selfStar: {
+    name: "Auto-star",
+    description: "Compter les réactions de l'auteur sur son propre message.",
+    type: ConfigType.BOOLEAN,
+    defaultValue: false,
+  },
+  allowedChannels: {
+    name: "Salons surveillés",
+    description: "Salons où surveiller les réactions (vide = tous les salons).",
+    type: [ConfigType.CHANNEL],
+  },
+  ignoreBotMessages: {
+    name: "Ignorer les bots",
+    description: "Ne pas starboarder les messages de bots.",
+    type: ConfigType.BOOLEAN,
+    defaultValue: true,
+  },
+  belowThresholdBehavior: {
+    name: "Sous le seuil",
+    description:
+      "Que faire quand les réactions repassent sous le seuil : 'remove' supprime l'entrée, 'keep' la garde.",
+    type: ConfigType.ENUM,
+    options: ["remove", "keep"] as const,
+    defaultValue: "keep",
+  },
+  embedColor: {
+    name: "Couleur de l'embed",
+    description: "Couleur de la bordure de l'embed starboard.",
+    type: ConfigType.ENUM,
+    options: ["default", "gold", "blue", "green", "red"] as const,
+    defaultValue: "gold",
+  },
+} satisfies ConfigSchema;
+
+export type StarboardConfigSchema = typeof starboardConfigSchema;

--- a/src/modules/starboard/starboard.module.ts
+++ b/src/modules/starboard/starboard.module.ts
@@ -15,7 +15,11 @@ export default defineModule({
 
   config: starboardConfigSchema,
 
-  intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessageReactions],
+  intents: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMessageReactions,
+    GatewayIntentBits.MessageContent,
+  ],
 
   onLoad(_client, registry) {
     registry.register(messageReactionAddListener);

--- a/src/modules/starboard/starboard.module.ts
+++ b/src/modules/starboard/starboard.module.ts
@@ -1,0 +1,38 @@
+import { GatewayIntentBits } from "discord.js";
+import logger from "#lib/logger.js";
+import { defineModule } from "#lib/module.js";
+import messageReactionAddListener from "./listeners/message-reaction-add.listener.js";
+import messageReactionRemoveListener from "./listeners/message-reaction-remove.listener.js";
+import { starboardConfigSchema } from "./starboard.config.js";
+
+export default defineModule({
+  id: "starboard",
+  name: "Starboard",
+  description:
+    "Reposte les messages populaires dans un salon dédié quand ils reçoivent assez de réactions. Supporte plusieurs émojis (dont customs), configuration par seuil, auto-star, et salons surveillés.",
+  version: "1.0.0",
+  author: "AsyncMod Team",
+
+  config: starboardConfigSchema,
+
+  intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessageReactions],
+
+  onLoad(_client, registry) {
+    registry.register(messageReactionAddListener);
+    registry.register(messageReactionRemoveListener);
+
+    logger.info("Module Starboard chargé avec succès");
+  },
+
+  onInstall(_client, guild) {
+    logger.info(
+      `Module Starboard installé sur le serveur "${guild.name}" (${guild.id})`
+    );
+  },
+
+  onUninstall(_client, guild) {
+    logger.info(
+      `Module Starboard désinstallé du serveur "${guild.name}" (${guild.id})`
+    );
+  },
+});

--- a/src/prisma/migrations/20260615150547_add_starboard_config/migration.sql
+++ b/src/prisma/migrations/20260615150547_add_starboard_config/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "StarboardEntry" (
+    "id" TEXT NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "originalMessageId" TEXT NOT NULL,
+    "originalChannelId" TEXT NOT NULL,
+    "starboardMessageId" TEXT NOT NULL,
+    "starboardChannelId" TEXT NOT NULL,
+    "reactionCount" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "StarboardEntry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "StarboardEntry_guildId_idx" ON "StarboardEntry"("guildId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StarboardEntry_guildId_originalMessageId_key" ON "StarboardEntry"("guildId", "originalMessageId");

--- a/src/prisma/migrations/20260615154335_add_starboard_reactions/migration.sql
+++ b/src/prisma/migrations/20260615154335_add_starboard_reactions/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "StarboardEntry" ADD COLUMN     "reactions" JSONB NOT NULL DEFAULT '[]';

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -25,6 +25,7 @@ model StarboardEntry {
   starboardMessageId  String
   starboardChannelId  String
   reactionCount       Int      @default(0)
+  reactions           Json     @default("[]")
   createdAt           DateTime @default(now())
   updatedAt           DateTime @updatedAt
 


### PR DESCRIPTION
Closes #152

Module starboard entièrement personnalisable, utilisant Discord Components v2.

## Fonctionnement

- Surveille les réactions ajoutées/retirées sur les messages
- Quand un message atteint le seuil de réactions configuré, il est posté dans le channel starboard
- Le message starboard est mis à jour en temps réel (réactions ajoutées/retirées)
- Si le score repasse sous le seuil, le message est supprimé ou conservé selon la config

## Apparence (Components v2)

Deux containers sont utilisés quand le message original répond à un autre message :

### Container de réponse (si reply)
```
┌──────────────────────────────────┐
│ [pfp] ## ↪ @User · <t:R>          │
│       Contenu du message cité...  │
├──────────────────────────────────┤
│ 🖼️ X pièces jointes      [Btn]   │
└──────────────────────────────────┘
```

### Container du message original
```
┌──────────────────────────────────┐
│ [pfp] ## @User · <t:R>            │
│       Contenu du message...       │
│       [🖼️ gallery si images]      │
├──────────────────────────────────┤
│ ### ⭐ 5 · 🌟 3                  │
│ -# **X** unique(s)       [Btn]   │
└──────────────────────────────────┘
```

- Les pseudos sont des **mentions** (pings)
- Le bouton "Voir le message" renvoie vers le message original/cité
- Tout texte est tronqué à 1000 caractères

## Configuration (par serveur)

| Option | Description |
|---|---|
| `starboardChannel` | Channel où poster les messages starboard |
| `reactionEmojis` | Émojis comptabilisés (custom via `<:id>` ou nom) |
| `reactionCount` | Seuil de réactions requis |
| `selfStar` | Autoriser l'auteur à réagir à son propre message |
| `ignoreBotMessages` | Ignorer les messages des bots |
| `allowedChannels` | Restreindre à certains channels (vide = tous) |
| `belowThresholdBehavior` | `remove` ou `keep` quand le score repasse sous le seuil |
| `embedColor` | Couleur d'accent du container |

## Structure

```
src/modules/starboard/
├── starboard.module.ts
├── starboard.config.ts
├── listeners/
│   ├── message-reaction-add.listener.ts
│   └── message-reaction-remove.listener.ts
├── services/
│   └── starboard.service.ts
└── models/
    └── starboard.prisma
```

## Technique

- **Race condition** : Gérée via Prisma P2002 avec re-fetch et re-check du threshold
- **Partials** : Support des messages/réactions antérieurs au démarrage du bot
- **Components v2** : Containers, Sections, TextDisplay, MediaGallery, Button accessories
- **Logs** : Format structuré Pino avec `{ err }`